### PR TITLE
New feature: preview link for PDF files

### DIFF
--- a/fastdownload.js
+++ b/fastdownload.js
@@ -27,6 +27,7 @@ var disable_download_popup_sel = function(selector){
 			$('<a>').
 				attr('href', 'http://docs.google.com/viewer?url=' + 
 					 encodeURIComponent( 'http://e3.nctu.edu.tw/NCTU_EASY_E3P/LMS2/' + url)).
+				attr('target', '_black').
 				css('margin-left', '10px').
 				append('View').
 				insertAfter(obj);


### PR DESCRIPTION
In the content script -- fastdownload.js ,if we get the file name with /pdf$/i,
an &lt;a&gt; preview tag will be append to the file link.

I use [Google Doc Viewer](https://docs.google.com/viewer) for previewing.
